### PR TITLE
fixed travis url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Generator jekyll
-[![Build Status](https://secure.travis-ci.org/Thomas-Lebeau/generator-jekyll.png?branch=master)](https://travis-ci.org/Thomas-Lebeau/generator-jekyll)
+[![Build Status](https://secure.travis-ci.org/thomas-lebeau/generator-jekyll.png?branch=master)](https://travis-ci.org/thomas-lebeau/generator-jekyll)
 
 A generator for Yeoman to bootstrap a Jekyll blog.
 


### PR DESCRIPTION
The build status image (and link) were both breaking with the capitalization of the user name; I confirmed that the lower case'd version (as is the GitHub path) works as expected.
